### PR TITLE
🌱 Filter PRs by dates instead of milestones

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "axios": "0.19.0"
+    "axios": "0.19.0",
+    "moment": "=2.24.0"
   }
 }


### PR DESCRIPTION
Since we no longer use milestones on PRs, I had to find another way to get PRs of the last sprint.

The solution is to filter PRs with `mergedAt` in between `sprintEnd` and `sprintEnd - sprintLengthDays`
where `sprintEnd` and `sprintLengthDays` are optional command line arguments
with defaults `sprintEnd = today`; `sprintLengthDays = 12`
since our sprints start on Monday and end on Friday

Since the second parameter (`milestoneId`) is not needed anymore, I changed it to `projectName`, so we can run the report also for other projects, e.g. `lisk-service`